### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [ push ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jjrdk/opencertserver/security/code-scanning/17](https://github.com/jjrdk/opencertserver/security/code-scanning/17)

Add an explicit `permissions` block in `.github/workflows/github.yml` at the workflow root, directly under the trigger (`on:`) and before `jobs:`.  
For this workflow, the least-privilege baseline is:

- `contents: read`

This preserves existing behavior (checkout/build/test) while ensuring token scopes are explicitly constrained and documented. No imports, methods, or external definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
