### PR TITLE
Potential fix for code scanning alert no. 3: Log entries created from user input

### DIFF
--- a/src/opencertserver.acme.aspnetclient/Certes/AcmeChallengeApprovalMiddleware.cs
+++ b/src/opencertserver.acme.aspnetclient/Certes/AcmeChallengeApprovalMiddleware.cs
@@ -35,9 +35,14 @@ public sealed class AcmeChallengeApprovalMiddleware : ILetsEncryptChallengeAppro
     private async Task ProcessAcmeChallenge(HttpContext context)
     {
         var path = context.Request.Path.ToString();
+        var safePathForLog = path
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace("\u2028", string.Empty)
+            .Replace("\u2029", string.Empty);
         _logger.LogDebug(
             "Challenge invoked: {ChallengePath} by {IpAddress}",
-            path,
+            safePathForLog,
             context.Connection.RemoteIpAddress);
 
         var requestedToken = path[$"{MagicPrefix}/".Length..];
@@ -47,7 +52,7 @@ public sealed class AcmeChallengeApprovalMiddleware : ILetsEncryptChallengeAppro
         {
             _logger.LogInformation(
                 "The given challenge did not match {ChallengePath} among {AllChallenges}",
-                path,
+                safePathForLog,
                 allChallenges);
             await _next(context).ConfigureAwait(false);
             return;


### PR DESCRIPTION
Potential fix for [https://github.com/jjrdk/opencertserver/security/code-scanning/3](https://github.com/jjrdk/opencertserver/security/code-scanning/3)

To fix this safely without changing middleware behavior, sanitize the user-controlled path **only for logging** by stripping newline/control-separator characters before passing it to `_logger`. Keep the original `path` unchanged for token parsing/matching logic.

Best fix in this file:
- In `ProcessAcmeChallenge`, introduce a `safePathForLog` variable derived from `path`.
- Remove `\r`, `\n`, and Unicode line separators (`\u2028`, `\u2029`) from that variable.
- Use `safePathForLog` in both log calls that currently use `path` (lines 40 and 50), so all path logging is consistently safe.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
