### PR TITLE
CAAIdentities should be array of string and is read from configuration

### DIFF
--- a/src/opencertserver.acme.abstractions/HttpModel/DirectoryMetadata.cs
+++ b/src/opencertserver.acme.abstractions/HttpModel/DirectoryMetadata.cs
@@ -17,9 +17,9 @@ public sealed class DirectoryMetadata
     /// </summary>
     public string? Website { get; set; }
     /// <summary>
-    /// Gets or sets the CAA identities string, if present.
+    /// Gets or sets the CAA identities, if present.
     /// </summary>
-    public string? CAAIdentities { get; set; }
+    public string[]? CAAIdentities { get; set; }
     /// <summary>
     /// Gets or sets a value indicating whether external account binding is required.
     /// </summary>

--- a/src/opencertserver.acme.server/Configuration/ACMEServerOptions.cs
+++ b/src/opencertserver.acme.server/Configuration/ACMEServerOptions.cs
@@ -9,4 +9,9 @@ public sealed class AcmeServerOptions
     public bool ExternalAccountRequired { get; set; }
 
     public TOSOptions TOS { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the CAA identities that are served in the ACME directory.
+    /// </summary>
+    public string[]? CAAIdentities { get; set; }
 }

--- a/src/opencertserver.acme.server/Endpoints/DirectoryEndpoints.cs
+++ b/src/opencertserver.acme.server/Endpoints/DirectoryEndpoints.cs
@@ -35,7 +35,7 @@ public static class DirectoryEndpoints
                 Meta = new Abstractions.HttpModel.DirectoryMetadata
                 {
                     ExternalAccountRequired = options.ExternalAccountRequired,
-                    CAAIdentities           = null,
+                    CAAIdentities           = options.CAAIdentities,
                     TermsOfService          = options.TOS.RequireAgreement ? options.TOS.Url : null,
                     Website                 = options.WebsiteUrl,
                     ChallengeTypesWithAdditionalContent = ChallengeTypes.AllTypes


### PR DESCRIPTION
CAAIdentities should be array of string

CAAIdentities is read from configuration i.e. appsettings.json